### PR TITLE
Create requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,10 @@
+numpy
+PyQt5
+threading
+pyserial
+ctypes
+pydicom
+scipy
+matplotlib
+tkinter
+configparser


### PR DESCRIPTION
Fixes #3 

...to some extent. @schneidorlein can you check that installing the packages specified in the requirements.txt does the trick when you create a new environment and install ScatERR?